### PR TITLE
Add endpoint config to init

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"regexp"
+
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"github.com/workos/workos-cli/internal/config"
-	"regexp"
 )
 
 func init() {
@@ -24,6 +25,7 @@ var initCmd = &cobra.Command{
 			apiKey      string
 			name        string
 			environment string
+			endpoint    string
 		)
 
 		err := huh.NewInput().
@@ -56,12 +58,21 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
+		err = huh.NewInput().
+			Title("Enter an API endpoint (optional, defaults to https://api.workos.com).").
+			Value(&endpoint).
+			Run()
+		if err != nil {
+			return err
+		}
+
 		fmt.Println("creating ~/.workos.json")
 		apiKeyMap := make(map[string]config.ApiKey)
 		apiKeyMap[name] = config.ApiKey{
 			Value:       apiKey,
 			Name:        name,
 			Environment: environment,
+			Endpoint:    endpoint,
 		}
 		newConfig := config.Config{
 			ActiveApiKey: name,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"context"
+	"log"
+
 	"github.com/spf13/cobra"
 	"github.com/workos/workos-cli/internal/config"
 	"github.com/workos/workos-go/v4/pkg/organizations"
-	"log"
 )
 
 var cmdConfig *config.Config
@@ -47,5 +48,8 @@ func GetConfigOrExit() *config.Config {
 func initConfig() {
 	cmdConfig = config.LoadConfig()
 	organizations.SetAPIKey(cmdConfig.ApiKeys[cmdConfig.ActiveApiKey].Value)
+	if cmdConfig.ApiKeys[cmdConfig.ActiveApiKey].Endpoint != "" {
+		organizations.DefaultClient.Endpoint = cmdConfig.ApiKeys[cmdConfig.ActiveApiKey].Endpoint
+	}
 	//fga.SetApiKey(cmdConfig.ApiKeys[cmdConfig.ActiveApiKey].Value)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type ApiKey struct {
 	Name        string `mapstructure:"name"        json:"name"`
 	Value       string `mapstructure:"value"       json:"value"`
 	Environment string `mapstructure:"environment" json:"environment"`
+	Endpoint    string `mapstructure:"endpoint"    json:"endpoint"`
 }
 
 func (c Config) Write() error {


### PR DESCRIPTION
Adding optionally configuring an endpoint for an api key.  This will allow to test against a locally deployed version of the api.