### PR TITLE
Use New GH Access Token Secret in Release Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,4 +23,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BREW_REPO_GH_TOKEN }}


### PR DESCRIPTION
Update the secret being used to get the GitHub access token in the release workflow