### PR TITLE
[FGA-47] Add environment variable overrides for cli environment configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 bin
+.idea

--- a/README.md
+++ b/README.md
@@ -49,3 +49,46 @@ Once initialized, the CLI is ready to use:
 ```shell
 workos [cmd] [args]
 ```
+
+### Environment Variables
+WorkOS CLI support environment variables for initialization and environment management.
+
+| Environment Variable              | Description                                                                                                                                   | Supported Values     |
+|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| WORKOS_ACTIVE_ENVIRONMENT         | Sets the selected environment in your .workos.json file. Use `env` to override environment configs with other environment variable overrides. |                      |
+| WORKOS_ENVIRONMENTS_ENV_NAME      | Sets the name of the environment                                                                                                              |                      |
+| WORKOS_ENVIRONMENTS_ENV_ENDPOINT  | Sets the base endpoint for the environment                                                                                                    |                      |
+| WORKOS_ENVIRONMENTS_ENV_API_KEY   | Sets the API key for the environment                                                                                                          |                      |
+| WORKOS_ENVIRONMENTS_ENV_TYPE      | Sets the env type for the environment                                                                                                         | Production / Sandbox |
+
+#### Examples
+
+##### Set the active environment
+
+```shell
+export WORKOS_ACTIVE_ENVIRONMENT=local
+```
+
+```json
+// .workos.json
+{
+  "environments": {
+    "local": {
+      "endpoint": "http://localhost:8001",
+      "apiKey": "<YOUR_KEY>",
+      "type": "Sandbox",
+      "name": "local"
+    }
+  }
+}
+```
+
+##### Headless Mode
+
+```shell
+export WORKOS_ACTIVE_ENVIRONMENT=env
+export WORKOS_ENVIRONMENTS_ENV_NAME=local
+export WORKOS_ENVIRONMENTS_ENV_ENDPOINT=http://localhost:8001
+export WORKOS_ENVIRONMENTS_ENV_API_KEY=<YOUR_KEY>
+export WORKOS_ENVIRONMENTS_ENV_TYPE=Sandbox
+```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ WorkOS CLI support environment variables for initialization and environment mana
 export WORKOS_ACTIVE_ENVIRONMENT=local
 ```
 
+`.workos.json`
 ```json
-// .workos.json
 {
   "environments": {
     "local": {

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ workos [cmd] [args]
 ### Environment Variables
 WorkOS CLI support environment variables for initialization and environment management.
 
-| Environment Variable              | Description                                                                                                                                   | Supported Values     |
-|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
-| WORKOS_ACTIVE_ENVIRONMENT         | Sets the selected environment in your .workos.json file. Use `env` to override environment configs with other environment variable overrides. |                      |
-| WORKOS_ENVIRONMENTS_ENV_NAME      | Sets the name of the environment                                                                                                              |                      |
-| WORKOS_ENVIRONMENTS_ENV_ENDPOINT  | Sets the base endpoint for the environment                                                                                                    |                      |
-| WORKOS_ENVIRONMENTS_ENV_API_KEY   | Sets the API key for the environment                                                                                                          |                      |
-| WORKOS_ENVIRONMENTS_ENV_TYPE      | Sets the env type for the environment                                                                                                         | Production / Sandbox |
+| Environment Variable                  | Description                                                                                                                                        | Supported Values     |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
+| WORKOS_ACTIVE_ENVIRONMENT             | Sets the selected environment in your .workos.json file. Use `headless` to override environment configs with other environment variable overrides. |                      |
+| WORKOS_ENVIRONMENTS_HEADLESS_NAME     | Sets the name of the environment                                                                                                                   |                      |
+| WORKOS_ENVIRONMENTS_HEADLESS_ENDPOINT | Sets the base endpoint for the environment                                                                                                         |                      |
+| WORKOS_ENVIRONMENTS_HEADLESS_API_KEY  | Sets the API key for the environment                                                                                                               |                      |
+| WORKOS_ENVIRONMENTS_HEADLESS_TYPE     | Sets the env type for the environment                                                                                                              | Production / Sandbox |
 
 #### Examples
 
@@ -86,9 +86,9 @@ export WORKOS_ACTIVE_ENVIRONMENT=local
 ##### Headless Mode
 
 ```shell
-export WORKOS_ACTIVE_ENVIRONMENT=env
-export WORKOS_ENVIRONMENTS_ENV_NAME=local
-export WORKOS_ENVIRONMENTS_ENV_ENDPOINT=http://localhost:8001
-export WORKOS_ENVIRONMENTS_ENV_API_KEY=<YOUR_KEY>
-export WORKOS_ENVIRONMENTS_ENV_TYPE=Sandbox
+export WORKOS_ACTIVE_ENVIRONMENT=headless
+export WORKOS_ENVIRONMENTS_HEADLESS_NAME=local
+export WORKOS_ENVIRONMENTS_HEADLESS_ENDPOINT=http://localhost:8001
+export WORKOS_ENVIRONMENTS_HEADLESS_API_KEY=<YOUR_KEY>
+export WORKOS_ENVIRONMENTS_HEADLESS_TYPE=Sandbox
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	EnvVarPrefix       = "WORKOS"
-	EnvVarHeadlessMode = "env"
+	EnvVarHeadlessMode = "headless"
 	FilePrefix         = ".workos"
 	FileExtension      = "json"
 	FileName           = FilePrefix + "." + FileExtension
@@ -58,7 +58,7 @@ func createEmptyConfigFile(dir string) {
 
 // Loads config values from environment variables if active environment is set to headless mode
 // Supports overriding nested json keys with environment variables
-// e.g. environments.env.endpoint -> WORKOS_ENVIRONMENTS_ENV_ENDPOINT
+// e.g. environments.headless.endpoint -> WORKOS_ENVIRONMENTS_HEADLESS_ENDPOINT
 func loadEnvVarOverrides() {
 	viper.SetEnvPrefix(EnvVarPrefix)
 	// replace '.' in env var names with '_' to support overriding nested json keys
@@ -71,10 +71,10 @@ func loadEnvVarOverrides() {
 
 	// Binds environment variables to nested json keys which allows unmarshalling into struct
 	if activeEnvironment == EnvVarHeadlessMode {
-		_ = viper.BindEnv("environments.env.endpoint")
-		_ = viper.BindEnv("environments.env.type")
-		_ = viper.BindEnv("environments.env.name")
-		_ = viper.BindEnv("environments.env.api_key")
+		_ = viper.BindEnv("environments.headless.endpoint")
+		_ = viper.BindEnv("environments.headless.type")
+		_ = viper.BindEnv("environments.headless.name")
+		_ = viper.BindEnv("environments.headless.api_key")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,5 @@ func LoadConfig() *Config {
 	var config Config
 	err = viper.Unmarshal(&config)
 	cobra.CheckErr(err)
-
 	return &config
 }


### PR DESCRIPTION
Adds the following environment variable overrides for CLI environment configs.


| Environment Variable              | Description                                                                                                                                   | Supported Values     |
|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------------------|
| WORKOS_ACTIVE_ENVIRONMENT         | Sets the selected environment in your .workos.json file. Use `headless` to override environment configs with other environment variable overrides. |                      |
| WORKOS_ENVIRONMENTS_HEADLESS_NAME      | Sets the name of the environment                                                                                                              |                      |
| WORKOS_ENVIRONMENTS_HEADLESS_ENDPOINT  | Sets the base endpoint for the environment                                                                                                    |                      |
| WORKOS_ENVIRONMENTS_HEADLESS_API_KEY   | Sets the API key for the environment                                                                                                          |                      |
| WORKOS_ENVIRONMENTS_HEADLESS_TYPE      | Sets the env type for the environment                                                                                                         | Production / Sandbox |

Developers can use these environment variables to set their active environment or override the existing environment. 

## Examples

### Set the active environment

```shell
export WORKOS_ACTIVE_ENVIRONMENT=local
```

`.workos.json`
```json
{
  "environments": {
    "local": {
      "endpoint": "http://localhost:8001",
      "apiKey": "<YOUR_KEY>",
      "type": "Sandbox",
      "name": "local"
    }
  }
}
```

### Headless Mode

```shell
export WORKOS_ACTIVE_ENVIRONMENT=headless
export WORKOS_ENVIRONMENTS_HEADLESS_NAME=local
export WORKOS_ENVIRONMENTS_HEADLESS_ENDPOINT=http://localhost:8001/
export WORKOS_ENVIRONMENTS_HEADLESS_API_KEY=<YOUR_KEY>
export WORKOS_ENVIRONMENTS_HEADLESS_TYPE=Sandbox
```

[FGA-47](https://linear.app/workos/issue/FGA-47/workos-cli-github-action)