### PR TITLE
Add docker build to goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: "us-east-1"
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Docker Login
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
       - name: Release with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,3 +61,10 @@ brews:
     commit_author:
       name: WorkOS
       email: support@workos.com
+dockers:
+  - ids:
+      - linux
+    image_templates:
+      - "public.ecr.aws/p9s6f8y8/workos-cli:{{.Version}}"
+    build_flag_templates:
+      - "--platform=linux/amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY ./bin/workos /bin/workos
+ENTRYPOINT ["/bin/workos"]


### PR DESCRIPTION
Add docker image build to goreleaser.  Also, update github action workflow to login to the ecr public registry.  This will require aws credentials to be setup in the repo as actions secrets.