### PR TITLE
Use the correct arg to get the specified context in the `fga query` command

### DIFF
--- a/internal/cmd/fga.go
+++ b/internal/cmd/fga.go
@@ -559,9 +559,9 @@ var queryCmd = &cobra.Command{
 		}
 		var policyContext map[string]interface{}
 		if len(args) > 1 {
-			err := json.Unmarshal([]byte(args[3]), &policyContext)
+			err := json.Unmarshal([]byte(args[1]), &policyContext)
 			if err != nil {
-				return errors.Errorf("invalid context: %s", args[3])
+				return errors.Errorf("invalid context: %s", args[1])
 			}
 		}
 


### PR DESCRIPTION
## Description

Currently, using context with the `fga query` command is broken because the command is grabbing the context from the wrong argument, causing a panic. This change updates the `fga query` command to grab the context from the correct argument.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
