### PR TITLE
[FGA-98] Add `schema convert` and `schema apply` to FGA module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
-	github.com/workos/workos-go/v4 v4.16.0
+	github.com/workos/workos-go/v4 v4.21.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/workos/workos-go/v4 v4.16.0 h1:7BPvVKHI8qhOY/lH4EbBY2CtQs1CDJxXDbfTnYNma3g=
-github.com/workos/workos-go/v4 v4.16.0/go.mod h1:CwpXdAWhIE3SxV49qBVeYqWV8ojv0A0L9nM1xnho4/c=
 github.com/workos/workos-go/v4 v4.21.0 h1:pEoAJzCsBPU46dL6/PwwwS5BrBV8LWOZQp0mERrRPCc=
 github.com/workos/workos-go/v4 v4.21.0/go.mod h1:CwpXdAWhIE3SxV49qBVeYqWV8ojv0A0L9nM1xnho4/c=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/workos/workos-go/v4 v4.16.0 h1:7BPvVKHI8qhOY/lH4EbBY2CtQs1CDJxXDbfTnYNma3g=
 github.com/workos/workos-go/v4 v4.16.0/go.mod h1:CwpXdAWhIE3SxV49qBVeYqWV8ojv0A0L9nM1xnho4/c=
+github.com/workos/workos-go/v4 v4.21.0 h1:pEoAJzCsBPU46dL6/PwwwS5BrBV8LWOZQp0mERrRPCc=
+github.com/workos/workos-go/v4 v4.21.0/go.mod h1:CwpXdAWhIE3SxV49qBVeYqWV8ojv0A0L9nM1xnho4/c=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=

--- a/internal/cmd/fga.go
+++ b/internal/cmd/fga.go
@@ -675,14 +675,14 @@ var convertSchemaCMD = &cobra.Command{
 			if response.Warnings != nil {
 				printer.PrintMsg("Warnings:")
 				for _, warning := range response.Warnings {
-					printer.PrintMsg(fmt.Sprintf("%s", warning.Message))
+					printer.PrintMsg(warning.Message)
 				}
 				printer.PrintMsg("\n")
 			}
 
 			if response.Schema != nil {
 				printer.PrintMsg("Schema:")
-				printer.PrintMsg(fmt.Sprintf("%s", *response.Schema))
+				printer.PrintMsg(*response.Schema)
 			}
 
 			if response.ResourceTypes != nil {
@@ -733,7 +733,7 @@ var applySchemaCmd = &cobra.Command{
 		if response.Warnings != nil {
 			printer.PrintMsg("Warnings:")
 			for _, warning := range response.Warnings {
-				printer.PrintMsg(fmt.Sprintf("%s", warning.Message))
+				printer.PrintMsg(warning.Message)
 			}
 			printer.PrintMsg("\n")
 			if failOnWarnings {

--- a/internal/cmd/fga.go
+++ b/internal/cmd/fga.go
@@ -749,10 +749,7 @@ var applySchemaCmd = &cobra.Command{
 
 		ops := make([]fga.UpdateResourceTypeOpts, 0)
 		for _, rt := range response.ResourceTypes {
-			ops = append(ops, fga.UpdateResourceTypeOpts{
-				Type:      rt.Type,
-				Relations: rt.Relations,
-			})
+			ops = append(ops, fga.UpdateResourceTypeOpts(rt))
 		}
 
 		_, err = fga.BatchUpdateResourceTypes(context.Background(), ops)


### PR DESCRIPTION
Usage:
Convert a schema to json
```bash
workos fga schema convert ./schema.txt --to json 
```
Write to a file
```bash
./bin/workos-cli fga schema convert ./schema.txt --to json --output raw > test.json
```

Apply a schema
```bash
workos-cli fga schema apply ./schema.txt
```
Apply a schema with verbose output and fail on warnings
```bash
workos-cli fga schema apply ./schema.txt -v --strict
```
