### PR TITLE
[FGA-198] Update raw FGA schema convert output so that it includes version

### DIFF
--- a/internal/cmd/fga.go
+++ b/internal/cmd/fga.go
@@ -626,7 +626,7 @@ var convertSchemaCMD = &cobra.Command{
 	Use:     "convert <input_file>",
 	Short:   "Convert a schema to a JSON representation (or JSON to schema)",
 	Long:    "Convert a schema to a JSON representation (or JSON to schema) that can be used to apply resource types.",
-	Example: `workos fga schema convert schema.txt -o json`,
+	Example: `workos fga schema convert schema.txt --to json`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		to, err := cmd.Flags().GetString("to")
@@ -693,7 +693,7 @@ var convertSchemaCMD = &cobra.Command{
 			if response.Schema != nil {
 				printer.PrintMsg(*response.Schema)
 			} else {
-				printer.PrintJson(response.ResourceTypes)
+				printer.PrintJson(response)
 			}
 		default:
 			return errors.Errorf("invalid output: %s", output)


### PR DESCRIPTION
Fixes issue where raw resource types output of `workos fga schema convert` could not be converted back to a schema.

Before
```
➜ workos fga schema convert schema.txt --output raw
[
        {
            "type": "user",
            "relations": {}
        }
    ]

```

After
```
➜ workos fga schema convert schema.txt --output raw
{
    "version": "0.2",
    "resource_types": [
        {
            "type": "user",
            "relations": {}
        }
    ]
}
```