### PR TITLE
Pin third-party actions to currently used SHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         run: go build
         working-directory: cmd/workos
       - name: GoReleaser Check
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
         with:
           distribution: goreleaser
           version: latest
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: latest
           args: -v --timeout=5m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Release with GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
In light of the [recent compromise of the tj-actions/changed-files action](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), we’re trying to reduce the risk incurred from our use of third-party actions. 

[GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning third-party actions to a full length commit SHA as a good security practice, and as the only way to use an action as an immutable release.

This PR pins this repository’s third-party actions to their currently used version’s commit SHA, as indicated in the logs for the most recent workflow runs, or from the most recent matching release if logs are not available.

If desired, we can also look into adding a Dependabot configuration to help keep actions updated by automatically creating update PRs when new versions are available.
